### PR TITLE
Fix: AM/PM Date Parsing Issue in Chronos Class

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
-  "name": "chronos",
+  "name": "@asidd/chronos",
   "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "chronos",
+      "name": "@asidd/chronos",
       "version": "1.1.2",
+      "license": "MIT",
       "devDependencies": {
         "jsdom": "^22.1.0",
         "typescript": "^5.0.2",

--- a/src/__tests__/format.test.ts
+++ b/src/__tests__/format.test.ts
@@ -53,3 +53,27 @@ describe("Chronos class format method", () => {
     expect(dateInstance.format(format)).toBe("Aug, 01");
   });
 });
+
+describe("Formatting dates", () => {
+  const format = "MM/DD/YYYY HH:mm";
+
+  it("should correctly format early morning dates", () => {
+    const chronos = new Chronos("07/28/2023 01:00", format);
+    expect(chronos.format("MM/DD/YYYY hh:mm A")).toBe("07/28/2023 01:00 AM");
+  });
+
+  it("should correctly format afternoon dates", () => {
+    const chronos = new Chronos("07/28/2023 13:00", format);
+    expect(chronos.format("MM/DD/YYYY hh:mm A")).toBe("07/28/2023 01:00 PM");
+  });
+
+  it("should correctly handle dates near midnight", () => {
+    const chronos = new Chronos("07/28/2023 00:00", format);
+    expect(chronos.format("MM/DD/YYYY hh:mm A")).toBe("07/28/2023 12:00 AM");
+  });
+
+  it("should correctly handle dates near noon", () => {
+    const chronos = new Chronos("07/28/2023 12:00", format);
+    expect(chronos.format("MM/DD/YYYY hh:mm A")).toBe("07/28/2023 12:00 PM");
+  });
+});

--- a/src/__tests__/parse.test.ts
+++ b/src/__tests__/parse.test.ts
@@ -39,3 +39,51 @@ describe("Parse date function", () => {
     });
   });
 });
+
+describe("parse AM/PM", () => {
+  const format = "MM/DD/YYYY hh:mm A";
+
+  it("should correctly parse AM dates", () => {
+    const chronos = new Chronos("07/28/2023 01:00 AM", format);
+    expect(chronos.format(format)).toBe("07/28/2023 01:00 AM");
+  });
+
+  it("should correctly parse PM dates", () => {
+    const chronos = new Chronos("07/28/2023 01:00 PM", format);
+    expect(chronos.format(format)).toBe("07/28/2023 01:00 PM");
+  });
+
+  it("should correctly handle dates near midnight", () => {
+    const chronos = new Chronos("07/28/2023 12:00 AM", format);
+    expect(chronos.format(format)).toBe("07/28/2023 12:00 AM");
+  });
+
+  it("should correctly handle dates near noon", () => {
+    const chronos = new Chronos("07/28/2023 12:00 PM", format);
+    expect(chronos.format(format)).toBe("07/28/2023 12:00 PM");
+  });
+});
+
+describe("Parsing dates", () => {
+  const format = "MM/DD/YYYY hh:mm A";
+
+  it("should correctly parse AM dates", () => {
+    const chronos = new Chronos("07/28/2023 01:00 AM", format);
+    expect(chronos.format("MM/DD/YYYY HH:mm")).toBe("07/28/2023 01:00");
+  });
+
+  it("should correctly parse PM dates", () => {
+    const chronos = new Chronos("07/28/2023 01:00 PM", format);
+    expect(chronos.format("MM/DD/YYYY HH:mm")).toBe("07/28/2023 13:00");
+  });
+
+  it("should correctly handle dates near midnight", () => {
+    const chronos = new Chronos("07/28/2023 12:00 AM", format);
+    expect(chronos.format("MM/DD/YYYY HH:mm")).toBe("07/28/2023 00:00");
+  });
+
+  it("should correctly handle dates near noon", () => {
+    const chronos = new Chronos("07/28/2023 12:00 PM", format);
+    expect(chronos.format("MM/DD/YYYY HH:mm")).toBe("07/28/2023 12:00");
+  });
+});

--- a/src/chronos.ts
+++ b/src/chronos.ts
@@ -50,13 +50,17 @@ class Chronos {
 
   parseToObj: IparseToObj = (dateString, formatString) => {
     let formatRegex = /(YYYY|YY|MMMM|MMM|MM|DD|hh|HH|mm|ss|sss|a|A|Z)/g;
-    let valueComponents = dateString.split(/\D+/);
+    let valueComponents = dateString.split(/\W+/);
     let formatComponents = formatString.match(formatRegex);
 
     let dateObject =
       formatComponents?.reduce(
         (acc: { [key: string]: string }, key: string, index: number) => {
-          acc[key] = valueComponents ? valueComponents[index] : "";
+          if (key === "a" || key === "A") {
+            acc["ampm"] = valueComponents ? valueComponents[index] : "";
+          } else {
+            acc[key] = valueComponents ? valueComponents[index] : "";
+          }
           return acc;
         },
         {}
@@ -100,6 +104,7 @@ class Chronos {
 
   convertTo24HourFormat: IconvertTo24HourFormat = (hh, ampm) => {
     if (hh === undefined) return "00";
+    console.log(ampm, hh);
 
     const isPM = ampm === "PM";
     const hour12 = parseInt(hh, 10);


### PR DESCRIPTION
In the Chronos class, we identified an issue where AM dates were incorrectly parsed as PM and vice versa. This was due to a problem in the parsing methods where the AM/PM parameter was not being handled correctly.

This MR addresses this issue by ensuring the AM/PM parameter is correctly passed and interpreted during the date parsing process. We have added new test cases to validate this fix and all existing and new tests are passing.

Once merged, the library will be able to correctly parse and format dates in both 12-hour and 24-hour formats.