### PR TITLE
Remove unnecessary log statement from method

### DIFF
--- a/src/chronos.ts
+++ b/src/chronos.ts
@@ -104,7 +104,6 @@ class Chronos {
 
   convertTo24HourFormat: IconvertTo24HourFormat = (hh, ampm) => {
     if (hh === undefined) return "00";
-    console.log(ampm, hh);
 
     const isPM = ampm === "PM";
     const hour12 = parseInt(hh, 10);


### PR DESCRIPTION
In this merge request, I've removed an unnecessary logging statement that was left in one of the methods by mistake.

Changes made:
- Removed the log statement from the `convertTo24HourFormat` method in the `convertTo24HourFormat` file.

This change is expected to improve the readability of the console output and ensure that only meaningful and useful logs are printed.

Please review the changes and provide feedback if necessary.
